### PR TITLE
Fix: Token modal and event listener initialization

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,6 +58,7 @@
         <div class="modal">
             <div class="modal-header">
                 <h3>🔐 Connect to GitHub</h3>
+                <button type="button" class="close-btn" id="closeTokenModal">&times;</button>
             </div>
             <form id="tokenForm">
                 <p class="modal-intro">


### PR DESCRIPTION
## Summary
Fixes critical usability bugs preventing first-time users from using the dashboard.

## Problems Fixed
1. **Token modal was inescapable** - No close button, no click-outside-to-close, Escape key wasn't wired up
2. **'Connect' button did nothing** - Token form submit listener was set up in `setupEventListeners()`, which only runs *after* successful authentication (chicken-and-egg problem)
3. **'Add Task' buttons didn't work** - Event listeners only initialized after API calls succeeded; any API error left UI broken

## Changes
- Created `setupTokenForm()` method that runs immediately on init
- Added close button (×) to token modal
- Added click-outside-to-close for token modal  
- Added Escape key to close token modal
- Moved `setupEventListeners()` and `setupDragAndDrop()` to run before API calls
- Added initialization guards to prevent duplicate listeners on re-init

## Testing
1. Clear localStorage (`localStorage.removeItem('github_token')`)
2. Refresh dashboard - token modal should appear
3. Verify: close button works, clicking outside works, Escape works
4. Enter valid token, click Connect - modal should close and dashboard should load
5. Click 'Add Task' - task modal should open