### PR TITLE
Add sidebar navigation with Create Task action

### DIFF
--- a/app.js
+++ b/app.js
@@ -393,11 +393,13 @@ class TaskDashboard {
             document.getElementById('taskDueDate').value = task.dueDate;
             document.getElementById('taskPriority').value = task.priority;
             document.getElementById('taskStatus').value = task.status;
+            document.getElementById('taskStatusSelect').value = task.status;
         } else {
             this.currentTaskId = null;
             title.textContent = 'New Task';
             deleteBtn.style.display = 'none';
             document.getElementById('taskStatus').value = status;
+            document.getElementById('taskStatusSelect').value = status;
         }
         
         modal.classList.add('active');
@@ -425,10 +427,17 @@ class TaskDashboard {
         if (this._eventListenersInitialized) return;
         this._eventListenersInitialized = true;
 
-        // Add task buttons
-        document.querySelectorAll('.add-task-btn').forEach(btn => {
+        // Sidebar buttons
+        document.querySelectorAll('.sidebar-btn').forEach(btn => {
             btn.addEventListener('click', () => {
-                this.openModal(null, btn.dataset.status);
+                const action = btn.dataset.action;
+                if (action === 'create-task') {
+                    this.openModal(null, 'todo');
+                }
+                
+                // Update active state
+                document.querySelectorAll('.sidebar-btn').forEach(b => b.classList.remove('active'));
+                btn.classList.add('active');
             });
         });
 
@@ -500,7 +509,7 @@ class TaskDashboard {
             assignee: document.getElementById('taskAssignee').value,
             dueDate: document.getElementById('taskDueDate').value,
             priority: document.getElementById('taskPriority').value,
-            status: document.getElementById('taskStatus').value
+            status: document.getElementById('taskStatusSelect').value
         };
 
         if (!taskData.title) return;

--- a/index.html
+++ b/index.html
@@ -24,14 +24,24 @@
         <p>Syncing with GitHub...</p>
     </div>
     
-    <main class="board">
+    <div id="app-container">
+        <!-- Sidebar -->
+        <aside class="sidebar">
+            <nav class="sidebar-nav">
+                <button class="sidebar-btn active" data-action="create-task">
+                    <span class="sidebar-icon">➕</span>
+                    <span class="sidebar-label">Create Task</span>
+                </button>
+            </nav>
+        </aside>
+        
+        <main class="board">
         <div class="column" data-status="todo">
             <div class="column-header">
                 <h2>📋 To Do</h2>
                 <span class="task-count">0</span>
             </div>
             <div class="tasks" data-status="todo"></div>
-            <button class="add-task-btn" data-status="todo">+ Add Task</button>
         </div>
         
         <div class="column" data-status="in-progress">
@@ -40,7 +50,6 @@
                 <span class="task-count">0</span>
             </div>
             <div class="tasks" data-status="in-progress"></div>
-            <button class="add-task-btn" data-status="in-progress">+ Add Task</button>
         </div>
         
         <div class="column" data-status="done">
@@ -49,9 +58,9 @@
                 <span class="task-count">0</span>
             </div>
             <div class="tasks" data-status="done"></div>
-            <button class="add-task-btn" data-status="done">+ Add Task</button>
         </div>
     </main>
+    </div>
 
     <!-- Token Setup Modal -->
     <div class="modal-overlay" id="tokenModal">
@@ -109,6 +118,15 @@
                 <div class="form-group">
                     <label for="taskDescription">Description</label>
                     <textarea id="taskDescription" rows="3" placeholder="Add details..."></textarea>
+                </div>
+                
+                <div class="form-group">
+                    <label for="taskStatus">Status *</label>
+                    <select id="taskStatusSelect">
+                        <option value="todo">📋 To Do</option>
+                        <option value="in-progress">🔨 In Progress</option>
+                        <option value="done">✅ Done</option>
+                    </select>
                 </div>
                 
                 <div class="form-row">

--- a/styles.css
+++ b/styles.css
@@ -26,6 +26,8 @@ body {
     color: var(--text-primary);
     min-height: 100vh;
     line-height: 1.5;
+    display: flex;
+    flex-direction: column;
 }
 
 /* Header */
@@ -68,6 +70,77 @@ header {
     background: var(--border-color);
 }
 
+/* Sidebar */
+.sidebar {
+    width: 240px;
+    background: var(--bg-secondary);
+    border-right: 1px solid var(--border-color);
+    padding: 1rem 0;
+    flex-shrink: 0;
+}
+
+.sidebar-nav {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.sidebar-btn {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    background: transparent;
+    border: none;
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: all 0.2s ease;
+    text-align: left;
+    font-size: 0.95rem;
+}
+
+.sidebar-btn:hover {
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+}
+
+.sidebar-btn.active {
+    background: var(--bg-tertiary);
+    color: var(--accent-blue);
+    border-left: 3px solid var(--accent-blue);
+    padding-left: calc(1rem - 3px);
+}
+
+.sidebar-icon {
+    font-size: 1.2rem;
+    width: 24px;
+    text-align: center;
+}
+
+.sidebar-label {
+    font-weight: 500;
+}
+
+/* Main Content Wrapper */
+body {
+    display: flex;
+    flex-direction: column;
+}
+
+body > * {
+    flex-shrink: 0;
+}
+
+body > main {
+    flex: 1;
+}
+
+#app-container {
+    display: flex;
+    flex: 1;
+    min-height: 0;
+}
+
 /* Loading Overlay */
 .loader {
     position: fixed;
@@ -104,14 +177,30 @@ header {
     grid-template-columns: repeat(3, 1fr);
     gap: 1.5rem;
     padding: 1.5rem;
-    max-width: 1400px;
-    margin: 0 auto;
-    min-height: calc(100vh - 100px);
+    flex: 1;
+    overflow: auto;
 }
 
 @media (max-width: 900px) {
     .board {
         grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 768px) {
+    #app-container {
+        flex-direction: column;
+    }
+    
+    .sidebar {
+        width: 100%;
+        border-right: none;
+        border-bottom: 1px solid var(--border-color);
+    }
+    
+    .sidebar-nav {
+        flex-direction: row;
+        overflow-x: auto;
     }
 }
 


### PR DESCRIPTION
## Changes

- **Replaced column-level '+ Add Task' buttons** with a clean, extensible sidebar
- **Added 'Create Task'** as the first sidebar action (ready for future additions)
- **New Status field** in task creation form — choose To Do, In Progress, or Done when creating tasks
- **Improved layout:** Sidebar + board in a flex container
- **Responsive design:** Sidebar collapses to horizontal bar on mobile
- **Updated event listeners** to handle sidebar button clicks
- **Modal now allows status selection** during task creation (no longer locked to column)

## Why?

The previous design had a '+ Add Task' button in each column, which felt cluttered and wasn't scalable. This sidebar approach is cleaner and makes room for future features (filters, settings, analytics, etc.).

## Testing

- [ ] Sidebar displays correctly
- [ ] 'Create Task' button opens modal
- [ ] Status field in modal works
- [ ] Tasks are created in the correct column based on status selection
- [ ] Responsive layout works on mobile
- [ ] Editing existing tasks still works