### PR TITLE
HOTFIX: Exclude TIPs from main dashboard

### DIFF
--- a/app.js
+++ b/app.js
@@ -80,7 +80,13 @@ class TaskDashboard {
         ]);
         
         this.issues = [...open, ...closed]
-            .filter(issue => !issue.pull_request) // Exclude PRs
+            .filter(issue => {
+                if (issue.pull_request) return false; // Exclude PRs
+                const labels = issue.labels.map(l => l.name);
+                // Exclude TIPs (workshop items)
+                if (labels.includes('tip') || labels.includes('tip-archived')) return false;
+                return true;
+            })
             .map(issue => this.issueToTask(issue));
     }
 


### PR DESCRIPTION
## Problem

When creating a TIP in Task Workshop, it was also appearing as a task on the main dashboard (To Do column), creating duplicates when converting TIP → Task.

## Root Cause

`fetchIssues()` was pulling ALL issues from the repo, including those with `tip` and `tip-archived` labels.

## Fix

Added filter to exclude issues with `tip` or `tip-archived` labels from the main task board.

## Result

- TIPs now ONLY appear in Task Workshop
- Main dashboard shows actual tasks only
- No more duplicates when converting TIPs to tasks

Simple one-line filter fix. Merging immediately.